### PR TITLE
Fix typo in Occupation

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ const Page = () => (
 
     <Separator />
 
-    <Occupation>Gifted web developper</Occupation>
+    <Occupation>Gifted web developer</Occupation>
 
     <Separator />
 


### PR DESCRIPTION
Typical French typo spotted. 😉